### PR TITLE
chore: Do not install Python (v1) Docker Compose

### DIFF
--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -26,11 +26,6 @@
     state: latest
     cache_valid_time: 3600
 
-- name: Install Docker Compose
-  pip:
-    name: docker-compose
-    state: latest
-
 - name: Allow access to the Docker socket by some users
   user:
     name: '{{ item }}'


### PR DESCRIPTION
Compose now has its own Go implementation, integrated into Docker's
core.
