### PR TITLE
fix: Set a more logical auto-reboot time for unattended upgrades

### DIFF
--- a/roles/base/tasks/_packages.yml
+++ b/roles/base/tasks/_packages.yml
@@ -91,7 +91,7 @@
       line: 'Unattended-Upgrade::Automatic-Reboot "true";'
 
     - regexp: '^(?://)?Unattended-Upgrade::Automatic-Reboot-Time '
-      line: 'Unattended-Upgrade::Automatic-Reboot-Time "04:00";'
+      line: 'Unattended-Upgrade::Automatic-Reboot-Time "23:59";'
 
     - regexp: '^(?://)?Unattended-Upgrade::Update-Days '
       line: 'Unattended-Upgrade::Update-Days {"Sunday"};'


### PR DESCRIPTION
Unattended upgrades are run around 06:00 (via a systemd timer), so
rebooting should occur after that point in time (I guess).
